### PR TITLE
docs: removing Continuous Integration (CI) badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Conventional Commits Linter
-[![Continuous Integration (CI)](https://github.com/DeveloperC286/conventional_commits_linter/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/conventional_commits_linter/actions/workflows/continuous-integration.yml)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 

--- a/conventional_commits_linter/README.md
+++ b/conventional_commits_linter/README.md
@@ -1,6 +1,5 @@
 # Conventional Commits Linter
 [![crates.io](https://img.shields.io/crates/v/conventional_commits_linter)](https://crates.io/crates/conventional_commits_linter)
-[![Continuous Integration (CI)](https://github.com/DeveloperC286/conventional_commits_linter/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/conventional_commits_linter/actions/workflows/continuous-integration.yml)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 

--- a/conventional_commits_linter_lib/README.md
+++ b/conventional_commits_linter_lib/README.md
@@ -1,7 +1,6 @@
 # Conventional Commits Linter Library
 [![Documentation](https://docs.rs/conventional_commits_linter_lib/badge.svg)](https://docs.rs/conventional_commits_linter_lib)
 [![crates.io](https://img.shields.io/crates/v/conventional_commits_linter_lib)](https://crates.io/crates/conventional_commits_linter_lib)
-[![Continuous Integration (CI)](https://github.com/DeveloperC286/conventional_commits_linter/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/conventional_commits_linter/actions/workflows/continuous-integration.yml)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 


### PR DESCRIPTION
As the badge is for the latest workflow not the main branch.

We will also not block a release on checks, so need to run the CI workflow on the main branch. The checks are performed as part of the pull request.