### PR TITLE
build: removing metadata from unit-test target

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -178,7 +178,6 @@ compile:
 
 unit-test:
     FROM +rust-base
-    DO +COPY_METADATA
     DO +COPY_SOURCECODE
     RUN ./ci/unit-test.sh
 

--- a/src/commits/mod.rs
+++ b/src/commits/mod.rs
@@ -10,7 +10,6 @@ use crate::source::Source;
 
 pub mod commit;
 
-/// A representation of a range of commits within a Git repository.
 #[cfg(not(test))]
 pub struct Commits {
     commits: VecDeque<Commit>,


### PR DESCRIPTION
Previously it needed it for the lib tests which used the local history.