### PR TITLE
feat: accepting 'chore' as Angular commit type

### DIFF
--- a/end-to-end-tests/features/violations/angular_type_only.feature
+++ b/end-to-end-tests/features/violations/angular_type_only.feature
@@ -4,16 +4,27 @@ Feature: With the allow Angular types only flag, non-Angular types are picked up
   Scenario Outline:
     Given the context and environment are reset.
     When the flag --from-stdin is set and the standard input is "<standard_input>".
-    And the argument --output is set as "JSON".
     Then the linting passes.
     When the flag --allow-angular-type-only is set.
+    And the argument --output is set as "JSON".
     Then a non-Angular type violation is detected.
+
+
+    Examples:
+      | standard_input                      |
+      | "lint: clean up mutex returns\n\n"  |
+      | "composer: updated the packages"    |
+      | "major: release v3 (merge #51)\n\n" |
+
+
+  Scenario Outline:
+    Given the context and environment are reset.
+    When the flag --from-stdin is set and the standard input is "<standard_input>".
+    And the flag --allow-angular-type-only is set.
+    Then the linting passes.
 
 
     Examples:
       | standard_input                      |
       | "chore: update dependencies\n"      |
       | "chore(release): 6.5.0"             |
-      | "lint: clean up mutex returns\n\n"  |
-      | "composer: updated the packages"    |
-      | "major: release v3 (merge #51)\n\n" |

--- a/src/commits/commit/constants/mod.rs
+++ b/src/commits/commit/constants/mod.rs
@@ -1,7 +1,8 @@
 pub(super) const PRECEDING_WHITESPACE: &str = "^([[:space:]])";
 pub(super) const OPTIONAL_PRECEDING_WHITESPACE: &str = "^([[:space:]])*";
 pub(super) const OPTIONAL_EXCLAMATION: &str = "(!)?";
-pub(super) const ANGULAR_TYPE: &str = "(revert|build|ci|docs|feat|fix|perf|refactor|style|test)";
+pub(super) const ANGULAR_TYPE: &str =
+    "(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)";
 pub(super) const EMPTY_SCOPE: &str = r"\(([[:space:]])*\)";
 pub(super) const TYPE: &str = r"([[:alpha:]])+";
 pub(super) const OPTIONAL_SCOPE: &str = r"(\([[:alpha:]]+(-[[:alpha:]]+)*\))?";

--- a/src/commits/commit/tests/generated_tests/generation/variations/mod.rs
+++ b/src/commits/commit/tests/generated_tests/generation/variations/mod.rs
@@ -21,12 +21,10 @@ pub(super) const NON_ANGULAR_COMMIT_TYPE_VARIATIONS: &[&str] = &[
     "bug",
     "Bug",
     "BUG",
-    "chore",
-    "Chore",
 ];
 pub(super) const ANGULAR_COMMIT_TYPE_VARIATIONS: &[&str] = &[
-    "REVERT", "revert", "Build", "build", "ci", "CI", "docs", "feat", "FEAT", "fix", "Fix", "perf",
-    "refactor", "Refactor", "style", "Style", "test", "TEST",
+    "Build", "build", "chore", "Chore", "ci", "CI", "docs", "feat", "FEAT", "fix", "Fix", "perf",
+    "refactor", "Refactor", "REVERT", "revert", "style", "Style", "test", "TEST",
 ];
 
 const NO_SCOPE_VARIATIONS: &[&str] = &["", "!"];

--- a/src/commits/commit/tests/mod.rs
+++ b/src/commits/commit/tests/mod.rs
@@ -7,16 +7,20 @@ use super::*;
 #[rstest(
     commit_message,
     // Normal variatiants.
+    case("chore: 13.1.0"),
     case("fix: stop-parse was not being respected by commands (#1459)"),
     case("feat: zsh auto completion (#1292) "),
     case("fix: improve rpm release config (#64)\n\n* fix: improve rpm release config\r\n\r\nSigned-off-by: Carlos Alexandro Becker <caarlos0@gmail.com>\r\n\r\n* fix: template\r\n\r\nSigned-off-by: Carlos Alexandro Becker <caarlos0@gmail.com>\r\n"),
     case("feat: added support for \"rules\" debian package file (#49)\n\n* Added support for rules debian package file\r\n\r\n* Fixing typo in CONTRIBUTING.md\r\n\r\n* Runing 'make fmt' on project.\r\n"),
     case("ci: go mod tidy\n\nSigned-off-by: Carlos Alexandro Becker <caarlos0@gmail.com>\n"),
     // Breaking change variatiants.
+    case("chore!: drop Node 6 support (#1461)"),
     case("refactor!: remove package.json-based parserConfiguration (#1460)"),
     case("fix!: calling parse multiple times now appropriately maintains state (#\n\n"),
     case("feat!: drop support for EOL Node 8 (#1686)"),
     // Scope variatiants.
+    case("chore(major-release): release 17.7.0 (#2285)"),
+    case("chore(deps): bump anchore/sbom-action from 0.13.3 to 0.13.4 (#637)"),
     case("feat(completion): zsh auto completion (#1292) "),
     case("fix(deps): Update os-locale to avoid security vulnerability (#1270)"),
     case("refactor(ts): ship yargs.d.ts (#1671)"),
@@ -33,6 +37,7 @@ use super::*;
     case("style(guest-agent): Fix typo"),
     case("feat(guest-agent): Run commands as the primary user"),
     // Breaking change and scope variatiants.
+    case("chore(major-release)!: release 17.7.0 (#2285)"),
     case("feat(deps)!: yargs-parser now throws on invalid combinations of config (\n\n"),
     case("refactor(ts)!: ship yargs.d.ts (#1671)"),
     case("feat(guest-agent)!: run commands as the primary user"),
@@ -78,7 +83,6 @@ fn test_angular_type_conventional_commits(commit_message: &str) {
 #[rstest(
     commit_message,
     // Normal variatiants.
-    case("chore: 13.1.0"),
     case("samples: event.keyCode is deprecated, use new `.code` API (#2125)\n\nSome browser don't support `code` so I added a fallback for `keyCode`\r\n\r\nCo-authored-by: Benjamin E. Coe <bencoe@google.com>"),
     case("multiple: improved completion for choices\n\nfeat(completion): choices will now work for all possible aliases of an option and not just the default long option\r\nfix(completion): fix for completions that contain non-leading hyphens\r\nfix(completion): changed the check for option arguments to match options that begin with '-', instead of '--', to include short options"),
     case("bump: deps (#81)\n\nSigned-off-by: Carlos Alexandro Becker <caarlos0@gmail.com>"),
@@ -88,16 +92,12 @@ fn test_angular_type_conventional_commits(commit_message: &str) {
     case("tests: remove osx from CI, until Travis fixes OSX servers\n"),
     case("perfs: enhance contacts display and search (#2959)\n\n"),
     // Breaking change variatiants.
-    case("chore!: drop Node 6 support (#1461)"),
     case("feature!: incrementing API URL version (#1682)"),
     // Scope variatiants.
-    case("chore(major-release): release 17.7.0 (#2285)"),
-    case("chore(deps): bump anchore/sbom-action from 0.13.3 to 0.13.4 (#637)"),
     case("deps(security): CVE-2021-3807\n\nUpdate string-width to 4.2.3"),
     case("doc(webpack): webpack example (#1436)\n\n* doc: weback example\r\n* doc(webpack): ignore dynamic module loading warnings"),
     case("deps(cve-dep-bump): CVE-2021-3807\n\nUpdate string-width to 4.2.3"),
     // Breaking change and scope variatiants.
-    case("chore(major-release)!: release 17.7.0 (#2285)"),
     case("deps(security)!: CVE-2021-3807\n\nUpdate string-width to 4.2.3"),
     case("deps(cve-dep-bump)!: CVE-2021-3807\n\nUpdate string-width to 4.2.3"),
 )]


### PR DESCRIPTION
'chore' is not currently an Angular commit type.

* https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

However, it was previously and therefore it is a commonly used and accepted
Angular commit type.

* https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

_e.g._

* https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/config-conventional#type-enum

