### PR TITLE
refactor: Anyhow context over unwrap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,9 @@ fn main() {
 fn run(arguments: Arguments) -> Result<i32> {
     let commits = if arguments.from == "-" {
         let mut commit_message = String::new();
-        stdin().read_to_string(&mut commit_message).unwrap();
+        stdin()
+            .read_to_string(&mut commit_message)
+            .context("Unable to read the commit message from standard input.")?;
         Ok(Commits::from_commit_message(commit_message))
     } else {
         let repository =


### PR DESCRIPTION
Replace the .unwrap() on stdin read with .context(...)? so that a
failure reading the commit message from standard input (non-UTF-8
input, broken pipe) flows through anyhow to the error handling path.