### PR TITLE
refactor: build logger explicitly instead of mutating RUST_LOG

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,12 +26,20 @@ const ERROR_EXIT_CODE: i32 = 1;
 fn main() {
     let arguments = Arguments::parse();
 
-    // Set up logging: if verbose is true and RUST_LOG is not set, default to info level
-    if arguments.verbose && std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info");
+    // Set up logging. Log level precedence:
+    // - RUST_LOG, if set.
+    // - info, if --verbose is passed.
+    let mut logger = pretty_env_logger::formatted_builder();
+    match std::env::var("RUST_LOG") {
+        Ok(rust_log) => {
+            logger.parse_filters(&rust_log);
+        }
+        Err(_) if arguments.verbose => {
+            logger.filter_level(log::LevelFilter::Info);
+        }
+        Err(_) => {}
     }
-
-    pretty_env_logger::init();
+    logger.init();
 
     info!("Version {}.", env!("CARGO_PKG_VERSION"));
     debug!("The command line arguments provided are {arguments:?}.");


### PR DESCRIPTION
Replace the std::env::set_var("RUST_LOG", ...) round-trip with an
explicit pretty_env_logger builder. set_var is unsafe in Rust 2024 and
a footgun even in 2021 (mutating a process env var before init reads it).