### PR TITLE
refactor: replace #[macro_use] extern crate log with per-module use imports

### DIFF
--- a/src/commits/commit/mod.rs
+++ b/src/commits/commit/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result};
+use log::{info, trace};
 use regex::Regex;
 
 use crate::commit_type::CommitType;

--- a/src/commits/mod.rs
+++ b/src/commits/mod.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, VecDeque};
 
 use anyhow::{bail, Context, Result};
 use git2::{Oid, Repository, Revwalk};
+use log::{debug, info, warn};
 
 use crate::commit_type::CommitType;
 use crate::commits::commit::Commit;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,9 @@
-#[macro_use]
-extern crate log;
-extern crate pretty_env_logger;
-
 use std::io::{stdin, Read};
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use git2::Repository;
+use log::{debug, error, info};
 
 use crate::cli::Arguments;
 use crate::commits::Commits;


### PR DESCRIPTION
Drop the edition-2015 `#[macro_use] extern crate log;` and the
redundant `extern crate pretty_env_logger;` (referenced by path).
Import only the log macros each module actually uses.