### PR TITLE
docs: add missing chore type to --type help text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,7 @@ pub(crate) struct Arguments {
     #[arg(
         long = "type",
         default_value = "any",
-        help = "Allow the Conventional Commits type to only be (`build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test`, `revert`), otherwise linting for the commit will fail."
+        help = "Allow the Conventional Commits type to only be (`build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test`, `revert`), otherwise linting for the commit will fail."
     )]
     pub(crate) commit_type: crate::commit_type::CommitType,
 


### PR DESCRIPTION
The --type argument help text listed the accepted Angular types but
omitted chore, even though the ANGULAR_TYPE regex accepts it.