### PR TITLE
fix: print CommitTitleTooLong in the pretty output

### DIFF
--- a/src/linting_errors/pretty/mod.rs
+++ b/src/linting_errors/pretty/mod.rs
@@ -83,6 +83,14 @@ pub(crate) fn print_all(
             );
         }
 
+        if linting_errors.contains(&LintingError::CommitTitleTooLong) {
+            let _ = writeln!(
+                pretty_print,
+                "\t{} - Commit title is longer than the maximum allowed length.",
+                red.paint("X")
+            );
+        }
+
         pretty_print
     }
 

--- a/src/linting_errors/pretty/tests/mod.rs
+++ b/src/linting_errors/pretty/tests/mod.rs
@@ -36,18 +36,63 @@ fn test_pretty_print_from_commit_message(commit_message: &str, snapshot_name: &s
 }
 
 #[rstest(
+    commit_message,
+    max_commit_title_length,
+    snapshot_name,
+    case(
+        "feat: add new feature",
+        15,
+        "test_pretty_print_commit_title_too_long_case_1"
+    ),
+    case(
+        "doc(webpack):webpack example (#1436)",
+        15,
+        "test_pretty_print_commit_title_too_long_case_2"
+    )
+)]
+fn test_pretty_print_commit_title_too_long(
+    commit_message: &str,
+    max_commit_title_length: usize,
+    snapshot_name: &str,
+) {
+    // Given
+    let commits = crate::commits::Commits::from_commit_message(commit_message);
+    let linting_errors = commits
+        .lint(DEFAULT_COMMIT_TYPE, max_commit_title_length)
+        .unwrap();
+
+    // When
+    let pretty_print = linting_errors.pretty();
+
+    // Then
+    insta::assert_snapshot!(snapshot_name, pretty_print);
+}
+
+#[rstest(
     commit_messages,
+    max_commit_title_length,
     snapshot_name,
     case(
         &["feat()!: yargs-parser now throws on invalid combinations of config\n\n", "doc(webpack):webpack example (#1436)"],
+        DEFAULT_COMMIT_TITLE_LENGTH,
         "test_pretty_print_from_git_case_1"
     ),
     case(
         &["refactor(ts support)!: ship yargs.d.ts (#1671)", "feat!: drop support for EOL Node 8 (#1686)"],
+        DEFAULT_COMMIT_TITLE_LENGTH,
         "test_pretty_print_from_git_case_2"
     ),
+    case(
+        &["feat: add new feature", "doc(webpack):webpack example (#1436)"],
+        15,
+        "test_pretty_print_from_git_commit_title_too_long"
+    ),
 )]
-fn test_pretty_print_from_git(commit_messages: &[&str], snapshot_name: &str) {
+fn test_pretty_print_from_git(
+    commit_messages: &[&str],
+    max_commit_title_length: usize,
+    snapshot_name: &str,
+) {
     // Given
     let commits: Commits = Commits {
         source: Source::Git,
@@ -66,7 +111,7 @@ fn test_pretty_print_from_git(commit_messages: &[&str], snapshot_name: &str) {
     };
 
     let linting_errors = commits
-        .lint(DEFAULT_COMMIT_TYPE, DEFAULT_COMMIT_TITLE_LENGTH)
+        .lint(DEFAULT_COMMIT_TYPE, max_commit_title_length)
         .unwrap();
 
     // When

--- a/src/linting_errors/pretty/tests/snapshots/conventional_commits_linter__linting_errors__pretty__tests__test_pretty_print_commit_title_too_long_case_1.snap
+++ b/src/linting_errors/pretty/tests/snapshots/conventional_commits_linter__linting_errors__pretty__tests__test_pretty_print_commit_title_too_long_case_1.snap
@@ -1,0 +1,6 @@
+---
+source: src/linting_errors/pretty/tests/mod.rs
+expression: pretty_print
+---
+[1;31mMessage[0m - "feat: add new feature"
+	[1;31mX[0m - Commit title is longer than the maximum allowed length.

--- a/src/linting_errors/pretty/tests/snapshots/conventional_commits_linter__linting_errors__pretty__tests__test_pretty_print_commit_title_too_long_case_2.snap
+++ b/src/linting_errors/pretty/tests/snapshots/conventional_commits_linter__linting_errors__pretty__tests__test_pretty_print_commit_title_too_long_case_2.snap
@@ -1,0 +1,8 @@
+---
+source: src/linting_errors/pretty/tests/mod.rs
+expression: pretty_print
+---
+[1;31mMessage[0m - "doc(webpack):webpack example (#1436)"
+	[1;31mX[0m - Commit title does not comply with the Conventional Commits V1.0.0 specification.
+	[1;31mX[0m - Commit title has no space after the colon preceding the type and scope.
+	[1;31mX[0m - Commit title is longer than the maximum allowed length.

--- a/src/linting_errors/pretty/tests/snapshots/conventional_commits_linter__linting_errors__pretty__tests__test_pretty_print_from_git_commit_title_too_long.snap
+++ b/src/linting_errors/pretty/tests/snapshots/conventional_commits_linter__linting_errors__pretty__tests__test_pretty_print_from_git_commit_title_too_long.snap
@@ -1,0 +1,15 @@
+---
+source: src/linting_errors/pretty/tests/mod.rs
+expression: pretty_print
+---
+[1;31mCommit Hash[0m - 0000000000000000000000000000000000000000
+[1;31mMessage[0m - "feat: add new feature"
+	[1;31mX[0m - Commit title is longer than the maximum allowed length.
+
+[1;31mCommit Hash[0m - 1000000000000000000000000000000000000000
+[1;31mMessage[0m - "doc(webpack):webpack example (#1436)"
+	[1;31mX[0m - Commit title does not comply with the Conventional Commits V1.0.0 specification.
+	[1;31mX[0m - Commit title has no space after the colon preceding the type and scope.
+	[1;31mX[0m - Commit title is longer than the maximum allowed length.
+
+[1;31mX[0m - Found 4 separate linting errors across 2 commits.


### PR DESCRIPTION
The pretty printer, which is the default output mode, rendered a branch
for every LintingError variant except CommitTitleTooLong. A commit which
only violated --max-commit-title-length therefore printed a bare Message
line with no explanation.